### PR TITLE
Wait timeout for expected config status increase

### DIFF
--- a/testsuite/openshift/config.py
+++ b/testsuite/openshift/config.py
@@ -58,7 +58,7 @@ class BaseEnvoyConfig(OpenShiftObject, ABC):
             ports[listener["name"]] = listener["address"]["socket_address"]["port_value"]
         return ports
 
-    def wait_status(self, status: Status, timeout=30):
+    def wait_status(self, status: Status, timeout=60):
         """Waits until config has the expected status"""
         with oc.timeout(timeout):
 


### PR DESCRIPTION
This is mainly due to frequent failures of rollback tests. The timeout increase make them more stable.